### PR TITLE
Add more sorting algorithms in Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Python
+
+## ruff stuff
+.ruff_cache
+
+## pytest
+.pytest_cache

--- a/python/adspy/algorithms/sorting/bubble_sort.py
+++ b/python/adspy/algorithms/sorting/bubble_sort.py
@@ -10,6 +10,10 @@ from operator import gt, lt
 from typing import Any
 
 
+def _default_key(arg: Any) -> Any:
+    return arg
+
+
 def bubble_sort(
     seq: Sequence,
     key: None | Callable = None,
@@ -29,9 +33,6 @@ def bubble_sort(
     list
     """
 
-    def _default_key(arg: Any) -> Any:
-        return arg
-
     if key is None:
         key = _default_key
     if not isinstance(key, Callable):
@@ -39,7 +40,7 @@ def bubble_sort(
         raise TypeError(msg)
 
     lst = list(seq)
-    if (size := len(lst)) < 1:
+    if (size := len(lst)) < 2:
         return lst
     op = lt if reverse else gt
     while True:

--- a/python/adspy/algorithms/sorting/bubble_sort.py
+++ b/python/adspy/algorithms/sorting/bubble_sort.py
@@ -6,6 +6,7 @@ References:
 """
 
 from collections.abc import Callable, Sequence
+from operator import gt, lt
 from typing import Any
 
 
@@ -38,16 +39,16 @@ def bubble_sort(
         raise TypeError(msg)
 
     lst = list(seq)
-    size = len(lst)
+    if (size := len(lst)) < 1:
+        return lst
+    op = lt if reverse else gt
     while True:
         swapped = False
         for idx in range(1, size):
-            if key(lst[idx - 1]) > key(lst[idx]):
+            if op(key(lst[idx - 1]), key(lst[idx])):
                 lst[idx - 1], lst[idx] = lst[idx], lst[idx - 1]
                 swapped = True
         if not swapped:
             break
         size -= 1
-    if reverse:
-        lst.reverse()
     return lst

--- a/python/adspy/algorithms/sorting/bubble_sort.py
+++ b/python/adspy/algorithms/sorting/bubble_sort.py
@@ -12,6 +12,7 @@ from typing import Any
 def bubble_sort(
     seq: Sequence,
     key: None | Callable = None,
+    *,
     reverse: bool = False,
 ) -> list:
     """Returns the sorted list.

--- a/python/adspy/algorithms/sorting/common.py
+++ b/python/adspy/algorithms/sorting/common.py
@@ -47,3 +47,51 @@ def is_sorted(
         if not op(key(tup[idx - 1]), key(tup[idx])):
             return False
     return True
+
+
+def merge(
+    seq1: Sequence,
+    seq2: Sequence,
+    key: None | Callable = None,
+    *,
+    reverse: bool = False,
+) -> list:
+    """Returns the merged list of two sequences.
+
+    Parameters
+    ----------
+    seq1 : Sequence
+    seq2 : Sequence
+    key : None | Callable, default None
+    reverse : bool, default False
+
+    Returns
+    -------
+    list
+    """
+
+    def _default_key(arg: Any) -> Any:
+        return arg
+
+    if key is None:
+        key = _default_key
+    if not isinstance(key, Callable):
+        msg = f"{key} is not callable"
+        raise TypeError(msg)
+
+    merged = []
+    lst1, lst2 = map(list, (seq1, seq2))
+    len1, len2 = map(len, (lst1, lst2))
+    idx1, idx2 = 0, 0
+    while (idx1 < len1) and (idx2 < len2):
+        if key(seq1[idx1]) < key(seq2[idx2]):
+            merged.append(seq1[idx1])
+            idx1 += 1
+        else:
+            merged.append(seq2[idx2])
+            idx2 += 1
+    merged += seq1[idx1:]
+    merged += seq2[idx2:]
+    if reverse:
+        merged.reverse()
+    return merged

--- a/python/adspy/algorithms/sorting/common.py
+++ b/python/adspy/algorithms/sorting/common.py
@@ -1,9 +1,14 @@
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from operator import ge, gt, le, lt
+from typing import Any
 
 
 def is_sorted(
-    seq: Sequence, *, reverse: bool = False, strict: bool = False
+    seq: Sequence,
+    key: None | Callable = None,
+    *,
+    reverse: bool = False,
+    strict: bool = False,
 ) -> bool:
     """Returns True if the `seq` is sorted.
 
@@ -19,6 +24,15 @@ def is_sorted(
     bool
     """
 
+    def _default_key(arg: Any) -> Any:
+        return arg
+
+    if key is None:
+        key = _default_key
+    if not isinstance(key, Callable):
+        msg = f"{key} is not callable"
+        raise TypeError(msg)
+
     if reverse:
         op = ge
         if strict:
@@ -30,6 +44,6 @@ def is_sorted(
 
     tup = tuple(seq)
     for idx in range(1, len(tup)):
-        if not op(tup[idx - 1], tup[idx]):
+        if not op(key(tup[idx - 1]), key(tup[idx])):
             return False
     return True

--- a/python/adspy/algorithms/sorting/common.py
+++ b/python/adspy/algorithms/sorting/common.py
@@ -1,0 +1,35 @@
+from collections.abc import Sequence
+from operator import ge, gt, le, lt
+
+
+def is_sorted(
+    seq: Sequence, *, reverse: bool = False, strict: bool = False
+) -> bool:
+    """Returns True if the `seq` is sorted.
+
+    Parameters
+    ----------
+    reverse : bool, default False
+        True for the ascending order (equal items are acceptable)
+    strict: bool, default False
+        if True, then checking the strict order (no equality is allowed)
+
+    Returns
+    -------
+    bool
+    """
+
+    if reverse:
+        op = ge
+        if strict:
+            op = gt
+    else:
+        op = le
+        if strict:
+            op = lt
+
+    tup = tuple(seq)
+    for idx in range(1, len(tup)):
+        if not op(tup[idx - 1], tup[idx]):
+            return False
+    return True

--- a/python/adspy/algorithms/sorting/common.py
+++ b/python/adspy/algorithms/sorting/common.py
@@ -3,6 +3,10 @@ from operator import ge, gt, le, lt
 from typing import Any
 
 
+def _default_key(arg: Any) -> Any:
+    return arg
+
+
 def is_sorted(
     seq: Sequence,
     key: None | Callable = None,
@@ -23,9 +27,6 @@ def is_sorted(
     -------
     bool
     """
-
-    def _default_key(arg: Any) -> Any:
-        return arg
 
     if key is None:
         key = _default_key
@@ -56,7 +57,7 @@ def merge(
     *,
     reverse: bool = False,
 ) -> list:
-    """Returns the merged list of two sequences.
+    """Returns the merged list from two sequences.
 
     Parameters
     ----------
@@ -70,21 +71,20 @@ def merge(
     list
     """
 
-    def _default_key(arg: Any) -> Any:
-        return arg
-
     if key is None:
         key = _default_key
     if not isinstance(key, Callable):
         msg = f"{key} is not callable"
         raise TypeError(msg)
 
+    op = gt if reverse else lt
+
     merged = []
     lst1, lst2 = map(list, (seq1, seq2))
     len1, len2 = map(len, (lst1, lst2))
     idx1, idx2 = 0, 0
     while (idx1 < len1) and (idx2 < len2):
-        if key(seq1[idx1]) < key(seq2[idx2]):
+        if op(key(seq1[idx1]), key(seq2[idx2])):
             merged.append(seq1[idx1])
             idx1 += 1
         else:
@@ -92,6 +92,4 @@ def merge(
             idx2 += 1
     merged += seq1[idx1:]
     merged += seq2[idx2:]
-    if reverse:
-        merged.reverse()
     return merged

--- a/python/adspy/algorithms/sorting/insertion_sort.py
+++ b/python/adspy/algorithms/sorting/insertion_sort.py
@@ -1,0 +1,50 @@
+"""The "Merge sort" algorithm.
+
+References:
+
+- https://en.wikipedia.org/wiki/Insertion_sort
+"""
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+
+def insertion_sort(
+    seq: Sequence,
+    key: Callable | None = None,
+    *,
+    reverse: bool = False,
+) -> list:
+    """Returns the sorted list.
+
+    Parameters
+    ----------
+    seq : Sequence
+    key : None | Callable, default None
+    reverse : bool, default False
+
+    Returns
+    -------
+    list
+    """
+
+    def _default_key(arg: Any) -> Any:
+        return arg
+
+    if key is None:
+        key = _default_key
+    if not isinstance(key, Callable):
+        msg = f"{key} is not callable"
+        raise TypeError(msg)
+
+    lst = list(seq)
+    for idx in range(1, len(lst)):
+        curr = lst[idx]
+        jdx = idx - 1
+        while jdx > -1 and key(lst[jdx]) > key(lst[jdx + 1]):
+            lst[jdx + 1], lst[jdx] = lst[jdx], lst[jdx + 1]
+            jdx -= 1
+        lst[jdx + 1] = curr
+    if reverse:
+        lst.reverse()
+    return lst

--- a/python/adspy/algorithms/sorting/insertion_sort.py
+++ b/python/adspy/algorithms/sorting/insertion_sort.py
@@ -6,7 +6,12 @@ References:
 """
 
 from collections.abc import Callable, Sequence
+from operator import gt, lt
 from typing import Any
+
+
+def _default_key(arg: Any) -> Any:
+    return arg
 
 
 def insertion_sort(
@@ -28,9 +33,6 @@ def insertion_sort(
     list
     """
 
-    def _default_key(arg: Any) -> Any:
-        return arg
-
     if key is None:
         key = _default_key
     if not isinstance(key, Callable):
@@ -38,13 +40,14 @@ def insertion_sort(
         raise TypeError(msg)
 
     lst = list(seq)
-    for idx in range(1, len(lst)):
+    if (size := len(lst)) < 2:
+        return lst
+    op = lt if reverse else gt
+    for idx in range(1, size):
         curr = lst[idx]
         jdx = idx - 1
-        while jdx > -1 and key(lst[jdx]) > key(lst[jdx + 1]):
+        while jdx > -1 and op(key(lst[jdx]), key(lst[jdx + 1])):
             lst[jdx + 1], lst[jdx] = lst[jdx], lst[jdx + 1]
             jdx -= 1
         lst[jdx + 1] = curr
-    if reverse:
-        lst.reverse()
     return lst

--- a/python/adspy/algorithms/sorting/merge_sort.py
+++ b/python/adspy/algorithms/sorting/merge_sort.py
@@ -6,6 +6,7 @@ References:
 """
 
 from collections.abc import Callable, Sequence
+from typing import Any
 
 from adspy.algorithms.sorting.common import merge
 
@@ -44,6 +45,15 @@ def merge_sort(
         left_half = _merge_sort_rec(lst[:mid], key, reverse=reverse)
         right_half = _merge_sort_rec(lst[mid:], key, reverse=reverse)
         return merge(left_half, right_half, key, reverse=reverse)
+
+    def _default_key(arg: Any) -> Any:
+        return arg
+
+    if key is None:
+        key = _default_key
+    if not isinstance(key, Callable):
+        msg = f"{key} is not callable"
+        raise TypeError(msg)
 
     sorted_lst = _merge_sort_rec(list(seq), key=key, reverse=False)
     if reverse:

--- a/python/adspy/algorithms/sorting/merge_sort.py
+++ b/python/adspy/algorithms/sorting/merge_sort.py
@@ -11,6 +11,10 @@ from typing import Any
 from adspy.algorithms.sorting.common import merge
 
 
+def _default_key(arg: Any) -> Any:
+    return arg
+
+
 def merge_sort(
     seq: Sequence,
     key: None | Callable = None,
@@ -38,16 +42,12 @@ def merge_sort(
     ) -> list:
         """The actual recursive implementation."""
 
-        size = len(lst)
-        if size < 2:
+        if (size := len(lst)) < 2:
             return lst
         mid = size // 2
         left_half = _merge_sort_rec(lst[:mid], key, reverse=reverse)
         right_half = _merge_sort_rec(lst[mid:], key, reverse=reverse)
         return merge(left_half, right_half, key, reverse=reverse)
-
-    def _default_key(arg: Any) -> Any:
-        return arg
 
     if key is None:
         key = _default_key
@@ -55,7 +55,7 @@ def merge_sort(
         msg = f"{key} is not callable"
         raise TypeError(msg)
 
-    sorted_lst = _merge_sort_rec(list(seq), key=key, reverse=False)
-    if reverse:
-        sorted_lst.reverse()
-    return sorted_lst
+    lst = list(seq)
+    if len(lst) > 1:
+        lst = _merge_sort_rec(lst, key=key, reverse=reverse)
+    return lst

--- a/python/adspy/algorithms/sorting/merge_sort.py
+++ b/python/adspy/algorithms/sorting/merge_sort.py
@@ -1,0 +1,51 @@
+"""The "Merge sort" algorithm.
+
+References:
+
+- https://en.wikipedia.org/wiki/Merge_sort
+"""
+
+from collections.abc import Callable, Sequence
+
+from adspy.algorithms.sorting.common import merge
+
+
+def merge_sort(
+    seq: Sequence,
+    key: None | Callable = None,
+    *,
+    reverse: bool = False,
+) -> list:
+    """Returns the sorted list.
+
+    Parameters
+    ----------
+    seq : Sequence
+    key : None | Callable, default None
+    reverse : bool, default False
+
+    Returns
+    -------
+    list
+    """
+
+    def _merge_sort_rec(
+        lst: list,
+        key: Callable | None = None,
+        *,
+        reverse: bool = False,
+    ) -> list:
+        """The actual recursive implementation."""
+
+        size = len(lst)
+        if size < 2:
+            return lst
+        mid = size // 2
+        left_half = _merge_sort_rec(lst[:mid], key, reverse=reverse)
+        right_half = _merge_sort_rec(lst[mid:], key, reverse=reverse)
+        return merge(left_half, right_half, key, reverse=reverse)
+
+    sorted_lst = _merge_sort_rec(list(seq), key=key, reverse=False)
+    if reverse:
+        sorted_lst.reverse()
+    return sorted_lst

--- a/python/adspy/algorithms/sorting/selection_sort.py
+++ b/python/adspy/algorithms/sorting/selection_sort.py
@@ -1,0 +1,47 @@
+"""The "Selection sort" algorithm.
+
+References:
+
+- https://en.wikipedia.org/wiki/Selection_sort
+"""
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+
+def selection_sort(
+    seq: Sequence,
+    key: None | Callable = None,
+    *,
+    reverse: bool = False,
+) -> list:
+    """Returns the sorted list.
+
+    Parameters
+    ----------
+    seq : Sequence
+    key : None | Callable, default None
+    reverse : bool, default False
+
+    Returns
+    -------
+    list
+    """
+
+    def _default_key(arg) -> Any:
+        return arg
+
+    if key is None:
+        key = _default_key
+    lst = list(seq)
+    size = len(lst)
+    for idx in range(size):
+        imin = idx
+        for jdx in range(idx + 1, size):
+            if key(lst[jdx]) < key(lst[imin]):
+                imin = jdx
+        if imin != idx:
+            lst[idx], lst[imin] = lst[imin], lst[idx]
+    if reverse:
+        lst.reverse()
+    return lst

--- a/python/adspy/algorithms/sorting/selection_sort.py
+++ b/python/adspy/algorithms/sorting/selection_sort.py
@@ -10,6 +10,10 @@ from operator import gt, lt
 from typing import Any
 
 
+def _default_key(arg: Any) -> Any:
+    return arg
+
+
 def selection_sort(
     seq: Sequence,
     key: None | Callable = None,
@@ -29,9 +33,6 @@ def selection_sort(
     list
     """
 
-    def _default_key(arg: Any) -> Any:
-        return arg
-
     if key is None:
         key = _default_key
     if not isinstance(key, Callable):
@@ -39,7 +40,7 @@ def selection_sort(
         raise TypeError(msg)
 
     lst = list(seq)
-    if (size := len(lst)) < 1:
+    if (size := len(lst)) < 2:
         return lst
     op = gt if reverse else lt
     for idx in range(size):
@@ -49,6 +50,4 @@ def selection_sort(
                 imin = jdx
         if imin != idx:
             lst[idx], lst[imin] = lst[imin], lst[idx]
-    # if reverse:
-    #     lst.reverse()
     return lst

--- a/python/adspy/algorithms/sorting/selection_sort.py
+++ b/python/adspy/algorithms/sorting/selection_sort.py
@@ -28,11 +28,15 @@ def selection_sort(
     list
     """
 
-    def _default_key(arg) -> Any:
+    def _default_key(arg: Any) -> Any:
         return arg
 
     if key is None:
         key = _default_key
+    if not isinstance(key, Callable):
+        msg = f"{key} is not callable"
+        raise TypeError(msg)
+
     lst = list(seq)
     size = len(lst)
     for idx in range(size):

--- a/python/adspy/algorithms/sorting/selection_sort.py
+++ b/python/adspy/algorithms/sorting/selection_sort.py
@@ -6,6 +6,7 @@ References:
 """
 
 from collections.abc import Callable, Sequence
+from operator import gt, lt
 from typing import Any
 
 
@@ -38,14 +39,16 @@ def selection_sort(
         raise TypeError(msg)
 
     lst = list(seq)
-    size = len(lst)
+    if (size := len(lst)) < 1:
+        return lst
+    op = gt if reverse else lt
     for idx in range(size):
         imin = idx
         for jdx in range(idx + 1, size):
-            if key(lst[jdx]) < key(lst[imin]):
+            if op(key(lst[jdx]), key(lst[imin])):
                 imin = jdx
         if imin != idx:
             lst[idx], lst[imin] = lst[imin], lst[idx]
-    if reverse:
-        lst.reverse()
+    # if reverse:
+    #     lst.reverse()
     return lst

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,6 +40,7 @@ skip-magic-trailing-comma = false  # respect magic trailing commas.
 [tool.ruff.lint]
 select = [
     "B",  # flake8-bugbear
+    "ERA",  # eradicate
     "I",  # isort
     "Q",  # flake8-quotes
     "T",  # flake8-print-linter

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,12 +38,14 @@ quote-style = "double"
 skip-magic-trailing-comma = false  # respect magic trailing commas.
 
 [tool.ruff.lint]
-extend-select = [
+select = [
     "B",  # flake8-bugbear
+    "I",  # isort
     "Q",  # flake8-quotes
     "T",  # flake8-print-linter
     "UP",  # pyupgrade
 ]
+fixable = ["I"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]

--- a/python/tests/algorithms/sorting/test_bubble_sort.py
+++ b/python/tests/algorithms/sorting/test_bubble_sort.py
@@ -69,7 +69,7 @@ def test_bubble_sort(seq: Sequence, key: None | Callable, reverse: bool):
 def test_bubble_sort_key(
     seq: Sequence, key: None | Callable, expectation: AbstractContextManager
 ):
-    lst = tuple(seq)
+    lst = list(seq)
 
     result = bubble_sort(lst, key=key)
 

--- a/python/tests/algorithms/sorting/test_bubble_sort.py
+++ b/python/tests/algorithms/sorting/test_bubble_sort.py
@@ -1,48 +1,37 @@
 """Test the "Bubble sort" implementation(s)."""
 
 from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
+from contextlib import nullcontext as does_not_raise
 from operator import itemgetter
 
 import pytest
 
 from adspy.algorithms.sorting.bubble_sort import bubble_sort
+from adspy.algorithms.sorting.common import is_sorted
 
 
 @pytest.mark.parametrize(
-    "seq, key, reverse",
+    "seq",
     [
-        ([], None, False),
-        ([1], None, False),
-        ([2, 1], None, False),
-        pytest.param(
-            (1, 0, -1),
-            None,
-            True,
-            marks=pytest.mark.xfail(reason="unstable"),
-        ),
-        pytest.param(
-            (-7, 5, 2, -5),
-            None,
-            False,
-            marks=pytest.mark.xfail(reason="unstable"),
-        ),
-        (
-            [(2, 1), (3, 4), (5, -5), (0, 2)],
-            itemgetter(-1),
-            True,
-        ),
-        pytest.param(
-            [-2, 2, 1, 0, -1],
-            abs,
-            False,
-            marks=pytest.mark.xfail(reason="mutual ambiguity"),
-        ),
-        pytest.param(
-            [0],
-            5,
-            False,
-            marks=pytest.mark.xfail(reason="key is not callable"),
-        ),
+        [],
+        [1],
+        (2, 0, 1),
+        {2, 4, 3, 1},
+    ],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        None,
+        abs,
+    ],
+)
+@pytest.mark.parametrize(
+    "reverse",
+    [
+        False,
+        True,
     ],
 )
 def test_bubble_sort(seq: Sequence, key: None | Callable, reverse: bool):
@@ -52,3 +41,39 @@ def test_bubble_sort(seq: Sequence, key: None | Callable, reverse: bool):
     expected = sorted(lst, key=key, reverse=reverse)
 
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("seq, key, expectation"),
+    [
+        ([0, 1, -1], None, does_not_raise()),
+        (
+            [(2, 1), (3, 4), (5, -5), (0, 2)],
+            itemgetter(-1),
+            does_not_raise(),
+        ),
+        pytest.param(
+            (0, 1, -1),
+            abs,
+            pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key failed to sort"),
+        ),
+        pytest.param(
+            [0],
+            5,
+            pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key is not callable"),
+        ),
+    ],
+)
+def test_bubble_sort_key(
+    seq: Sequence, key: None | Callable, expectation: AbstractContextManager
+):
+    lst = tuple(seq)
+
+    result = bubble_sort(lst, key=key)
+
+    assert is_sorted(result, key=key)
+    with expectation:
+        expected = sorted(lst, key=key)
+        assert result == expected

--- a/python/tests/algorithms/sorting/test_common.py
+++ b/python/tests/algorithms/sorting/test_common.py
@@ -1,4 +1,5 @@
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from operator import itemgetter
 
 import pytest
 
@@ -22,3 +23,23 @@ from adspy.algorithms.sorting.common import is_sorted
 )
 def test_is_sorted(seq: Sequence, reverse: bool, strict: bool, ans: bool):
     assert is_sorted(tuple(seq), reverse=reverse, strict=strict) == ans
+
+
+@pytest.mark.parametrize(
+    ("seq, key, ans"),
+    [
+        ([], None, True),
+        (
+            [(2, 1), (3, 4)],
+            itemgetter(-1),
+            True,
+        ),
+        (
+            [(2, 1), (3, 0)],
+            itemgetter(-1),
+            False,
+        ),
+    ],
+)
+def test_is_sorted_key(seq: Sequence, key: None | Callable, ans: bool):
+    assert is_sorted(tuple(seq), key=key) == ans

--- a/python/tests/algorithms/sorting/test_common.py
+++ b/python/tests/algorithms/sorting/test_common.py
@@ -1,0 +1,24 @@
+from collections.abc import Sequence
+
+import pytest
+
+from adspy.algorithms.sorting.common import is_sorted
+
+
+@pytest.mark.parametrize(
+    ("seq, reverse, strict, ans"),
+    [
+        ([], False, False, True),
+        ([], True, False, True),
+        ([1, 2], False, False, True),
+        ([1, 2], False, True, True),
+        ([3, 3], False, False, True),
+        ([3, 3], True, False, True),
+        ([3, 3], False, True, False),
+        ([3, 3], True, True, False),
+        ([4, 5], True, False, False),
+        ([4, 5], False, False, True),
+    ],
+)
+def test_is_sorted(seq: Sequence, reverse: bool, strict: bool, ans: bool):
+    assert is_sorted(tuple(seq), reverse=reverse, strict=strict) == ans

--- a/python/tests/algorithms/sorting/test_common.py
+++ b/python/tests/algorithms/sorting/test_common.py
@@ -3,7 +3,10 @@ from operator import itemgetter
 
 import pytest
 
-from adspy.algorithms.sorting.common import is_sorted
+from adspy.algorithms.sorting.common import (
+    is_sorted,
+    merge,
+)
 
 
 @pytest.mark.parametrize(
@@ -43,3 +46,16 @@ def test_is_sorted(seq: Sequence, reverse: bool, strict: bool, ans: bool):
 )
 def test_is_sorted_key(seq: Sequence, key: None | Callable, ans: bool):
     assert is_sorted(tuple(seq), key=key) == ans
+
+
+@pytest.mark.parametrize(
+    ("seq1", "seq2", "ans"),
+    [
+        ([4, 1], [3, 2], [3, 2, 4, 1]),
+        ([], [3, 2], [3, 2]),
+        ([4, 1], [], [4, 1]),
+        ([], [], []),
+    ],
+)
+def test_merge(seq1: Sequence, seq2: Sequence, ans: Sequence):
+    assert merge(seq1=seq1, seq2=seq2) == ans

--- a/python/tests/algorithms/sorting/test_common.py
+++ b/python/tests/algorithms/sorting/test_common.py
@@ -49,13 +49,19 @@ def test_is_sorted_key(seq: Sequence, key: None | Callable, ans: bool):
 
 
 @pytest.mark.parametrize(
-    ("seq1", "seq2", "ans"),
+    ("seq1", "seq2", "reverse", "ans"),
     [
-        ([4, 1], [3, 2], [3, 2, 4, 1]),
-        ([], [3, 2], [3, 2]),
-        ([4, 1], [], [4, 1]),
-        ([], [], []),
+        ([4, 1], [3, 2], False, [3, 2, 4, 1]),
+        ([], [3, 2], False, [3, 2]),
+        ([4, 1], [], False, [4, 1]),
+        ([1], [2], False, [1, 2]),
+        ([], [], False, []),
+        ([], [], True, []),
+        ([1, 2], [], True, [1, 2]),
+        ([], [3, 4], True, [3, 4]),
+        ([1], [2], True, [2, 1]),
+        ([2, 4], [3, 1], True, [3, 2, 4, 1]),
     ],
 )
-def test_merge(seq1: Sequence, seq2: Sequence, ans: Sequence):
-    assert merge(seq1=seq1, seq2=seq2) == ans
+def test_merge(seq1: Sequence, seq2: Sequence, reverse: bool, ans: list):
+    assert merge(seq1=seq1, seq2=seq2, reverse=reverse) == ans

--- a/python/tests/algorithms/sorting/test_insertion_sort.py
+++ b/python/tests/algorithms/sorting/test_insertion_sort.py
@@ -1,0 +1,79 @@
+"""Test the "Insertion sort" implementation(s)."""
+
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
+from contextlib import nullcontext as does_not_raise
+from operator import itemgetter
+
+import pytest
+
+from adspy.algorithms.sorting.common import is_sorted
+from adspy.algorithms.sorting.insertion_sort import insertion_sort
+
+
+@pytest.mark.parametrize(
+    "seq",
+    [
+        [],
+        [1],
+        (2, 0, 1),
+        {2, 4, 3, 1},
+    ],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        None,
+        abs,
+    ],
+)
+@pytest.mark.parametrize(
+    "reverse",
+    [
+        False,
+        True,
+    ],
+)
+def test_insertion_sort(seq: Sequence, key: None | Callable, reverse: bool):
+    lst = list(seq)
+
+    result = insertion_sort(lst, key=key, reverse=reverse)
+    expected = sorted(lst, key=key, reverse=reverse)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("seq, key, expectation"),
+    [
+        ([0, 1, -1], None, does_not_raise()),
+        (
+            [(2, 1), (3, 4), (5, -5), (0, 2)],
+            itemgetter(-1),
+            does_not_raise(),
+        ),
+        pytest.param(
+            (0, 1, -1),
+            abs,
+            pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key failed to sort"),
+        ),
+        pytest.param(
+            [0],
+            5,
+            pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key is not callable"),
+        ),
+    ],
+)
+def test_insertion_sort_key(
+    seq: Sequence, key: None | Callable, expectation: AbstractContextManager
+):
+    lst = list(seq)
+
+    result = insertion_sort(lst, key=key)
+
+    assert is_sorted(result, key=key)
+    with expectation:
+        expected = sorted(lst, key=key)
+        assert result == expected

--- a/python/tests/algorithms/sorting/test_merge_sort.py
+++ b/python/tests/algorithms/sorting/test_merge_sort.py
@@ -1,0 +1,79 @@
+"""Test the "Merge sort" implementation(s)."""
+
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
+from contextlib import nullcontext as does_not_raise
+from operator import itemgetter
+
+import pytest
+
+from adspy.algorithms.sorting.common import is_sorted
+from adspy.algorithms.sorting.merge_sort import merge_sort
+
+
+@pytest.mark.parametrize(
+    "seq",
+    [
+        [],
+        [1],
+        (2, 0, 1),
+        {2, 4, 3, 1},
+    ],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        None,
+        abs,
+    ],
+)
+@pytest.mark.parametrize(
+    "reverse",
+    [
+        False,
+        True,
+    ],
+)
+def test_merge_sort(seq: Sequence, key: None | Callable, reverse: bool):
+    lst = list(seq)
+
+    result = merge_sort(lst, key=key, reverse=reverse)
+    expected = sorted(lst, key=key, reverse=reverse)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("seq, key, expectation"),
+    [
+        ([0, 1, -1], None, does_not_raise()),
+        (
+            [(2, 1), (3, 4), (5, -5), (0, 2)],
+            itemgetter(-1),
+            does_not_raise(),
+        ),
+        pytest.param(
+            (0, 1, -1),
+            abs,
+            does_not_raise(),  # pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key failed to sort"),
+        ),
+        pytest.param(
+            [0],
+            5,
+            pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key is not callable"),
+        ),
+    ],
+)
+def test_merge_sort_key(
+    seq: Sequence, key: None | Callable, expectation: AbstractContextManager
+):
+    lst = list(seq)
+
+    result = merge_sort(lst, key=key)
+
+    assert is_sorted(result, key=key)
+    with expectation:
+        expected = sorted(lst, key=key)
+        assert result == expected

--- a/python/tests/algorithms/sorting/test_merge_sort.py
+++ b/python/tests/algorithms/sorting/test_merge_sort.py
@@ -56,7 +56,7 @@ def test_merge_sort(seq: Sequence, key: None | Callable, reverse: bool):
         pytest.param(
             (0, 1, -1),
             abs,
-            does_not_raise(),  # pytest.raises(AssertionError),
+            does_not_raise(),
             marks=pytest.mark.xfail(reason="key failed to sort"),
         ),
         pytest.param(

--- a/python/tests/algorithms/sorting/test_merge_sort.py
+++ b/python/tests/algorithms/sorting/test_merge_sort.py
@@ -18,6 +18,7 @@ from adspy.algorithms.sorting.merge_sort import merge_sort
         [1],
         (2, 0, 1),
         {2, 4, 3, 1},
+        [2, 3, 1, 1, 5],
     ],
 )
 @pytest.mark.parametrize(

--- a/python/tests/algorithms/sorting/test_selection_sort.py
+++ b/python/tests/algorithms/sorting/test_selection_sort.py
@@ -1,0 +1,79 @@
+"""Test the "Selection sort" implementation(s)."""
+
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
+from contextlib import nullcontext as does_not_raise
+from operator import itemgetter
+
+import pytest
+
+from adspy.algorithms.sorting.selection_sort import selection_sort
+from adspy.algorithms.sorting.common import is_sorted
+
+
+@pytest.mark.parametrize(
+    "seq",
+    [
+        [],
+        [1],
+        (2, 0, 1),
+        {2, 4, 3, 1},
+    ],
+)
+@pytest.mark.parametrize(
+    "key",
+    [
+        None,
+        abs,
+    ],
+)
+@pytest.mark.parametrize(
+    "reverse",
+    [
+        False,
+        True,
+    ],
+)
+def test_selection_sort(seq: Sequence, key: None | Callable, reverse: bool):
+    lst = list(seq)
+
+    result = selection_sort(lst, key=key, reverse=reverse)
+    expected = sorted(lst, key=key, reverse=reverse)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("seq, key, expectation"),
+    [
+        ([0, 1, -1], None, does_not_raise()),
+        (
+            [(2, 1), (3, 4), (5, -5), (0, 2)],
+            itemgetter(-1),
+            does_not_raise(),
+        ),
+        pytest.param(
+            (0, 1, -1),
+            abs,
+            pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key failed to sort"),
+        ),
+        pytest.param(
+            [0],
+            5,
+            pytest.raises(AssertionError),
+            marks=pytest.mark.xfail(reason="key is not callable"),
+        ),
+    ],
+)
+def test_selection_sort_key(
+    seq: Sequence, key: None | Callable, expectation: AbstractContextManager
+):
+    lst = tuple(seq)
+
+    result = selection_sort(lst, key=key)
+
+    assert is_sorted(result, key=key)
+    with expectation:
+        expected = sorted(lst, key=key)
+        assert result == expected

--- a/python/tests/algorithms/sorting/test_selection_sort.py
+++ b/python/tests/algorithms/sorting/test_selection_sort.py
@@ -7,8 +7,8 @@ from operator import itemgetter
 
 import pytest
 
-from adspy.algorithms.sorting.selection_sort import selection_sort
 from adspy.algorithms.sorting.common import is_sorted
+from adspy.algorithms.sorting.selection_sort import selection_sort
 
 
 @pytest.mark.parametrize(
@@ -69,7 +69,7 @@ def test_selection_sort(seq: Sequence, key: None | Callable, reverse: bool):
 def test_selection_sort_key(
     seq: Sequence, key: None | Callable, expectation: AbstractContextManager
 ):
-    lst = tuple(seq)
+    lst = list(seq)
 
     result = selection_sort(lst, key=key)
 


### PR DESCRIPTION
Algorithms to add:

- bubble_sort
- insertion_sort
- merge_sort
- selection_sort

Also the `common` module with sorting helpers is shipped along.